### PR TITLE
fix: :bug: ensures old actions are removed for unfound entities

### DIFF
--- a/server/services/emit-service.js
+++ b/server/services/emit-service.js
@@ -12,7 +12,14 @@ module.exports = ({ strapi }) => ({
 			model,
 			entity
 		);
-		console.log('emit', event, sanitizedEntity);
+		console.log('emit', event, {
+			id: sanitizedEntity.id, 
+			title: sanitizedEntity.title, 
+			slug: sanitizedEntity.slug, 
+			createdAt: sanitizedEntity.createdAt, 
+			updatedAt: sanitizedEntity.updatedAt, 
+			publishedAt: sanitizedEntity.publishedAt
+		});
 
 		strapi.eventHub.emit(event, {
 			model: model.modelName,

--- a/server/services/publication-service.js
+++ b/server/services/publication-service.js
@@ -61,6 +61,8 @@ module.exports = ({ strapi }) => ({
 		// ensure entity exists before attempting mutations.
 		if (!entity) {
 			console.error(`Entity ${record.entitySlug} with id ${entityId} not found`);
+			// remove any used actions related to deleted entity
+		    strapi.entityService.delete(actionUId, record.id);
 			return;
 		}
 


### PR DESCRIPTION
There are several actions relating to entities that have been deleted, stuck looping within the strapi entity service. 

This step will delete those actions 